### PR TITLE
substitutes all eval-cond with jumping

### DIFF
--- a/av-rule-174/check-deref.lisp
+++ b/av-rule-174/check-deref.lisp
@@ -49,7 +49,7 @@
       (when (and taint (is-untrusted ptr) (not checked))
         (notify-null-deref taint)))))
 
-(defmethod eval-cond (x)
+(defmethod jumping (x)
   (let ((taint (taint-get-direct 'const-ptr x)))
     (when taint
       (dict-add 'checked-pointer taint taint))))

--- a/must-check-value/must-check-value.lisp
+++ b/must-check-value/must-check-value.lisp
@@ -25,7 +25,7 @@
 (defmethod call (name _)
   (update-caller name))
 
-(defmethod eval-cond(cnd)
+(defmethod jumping (cnd)
   (let ((taint (taint-get-direct 'value-check/required cnd))
         (loc (dict-get 'value-check/location taint))
         (pc (dict-get 'value-check/required taint)))

--- a/warn-unused/warn-unused-result.lisp
+++ b/warn-unused/warn-unused-result.lisp
@@ -5,7 +5,7 @@
       (dict-add 'warn-unused-results/taints taint (incident-location))
       (check-if-used taint))))
 
-(defmethod eval-cond (cnd)
+(defmethod jumping (cnd)
   (let ((taint (taint-get-direct 'warn-unused cnd)))
     (when taint
       (dict-del 'warn-unused-results/taints taint)


### PR DESCRIPTION
since eval-cond is broken right now.