### PR TITLE
Fix deprecated 'opam config var' warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ PLUGIN_MAIN=""
 PLUGIN_DEPS=""
 PLUGIN_DESC=""
 HAS_BUILD_TOOLS="FALSE"
+export OPAMCLI=2.0
 
 # checks that necessary build tools are installed
 check_build_tools() {
@@ -98,7 +99,7 @@ install() {
     OLD=`pwd`
     cd $1
 
-    DST=`opam var prefix`/share/bap
+    DST=`opam config var prefix`/share/bap
     plugin=`find . -name "*.plugin" | head -n 1`
     recipe=`find . -name "*.recipe" | head -n 1`
 

--- a/build.sh
+++ b/build.sh
@@ -98,7 +98,7 @@ install() {
     OLD=`pwd`
     cd $1
 
-    DST=`opam config var prefix`/share/bap
+    DST=`opam var prefix`/share/bap
     plugin=`find . -name "*.plugin" | head -n 1`
     recipe=`find . -name "*.recipe" | head -n 1`
 


### PR DESCRIPTION
**description**
make build generates 
"[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0."

**solution**
use 'opam var' in the build.sh to eliminate warning